### PR TITLE
test: add GetCastsByHashtag RPC method

### DIFF
--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -34,6 +34,7 @@ service HubService {
   rpc GetCastsByFid(FidRequest) returns (MessagesResponse);
   rpc GetCastsByParent(CastsByParentRequest) returns (MessagesResponse);
   rpc GetCastsByMention(FidRequest) returns (MessagesResponse);
+  rpc GetCastsByHashtag(HashtagRequest) returns (MessagesResponse);
 
   // Reactions
   rpc GetReaction(ReactionRequest) returns (Message);


### PR DESCRIPTION
   Test for automatic documentation updates with Gemini API integration.
    Changes:
   - Added GetCastsByHashtag RPC method to HubService
